### PR TITLE
Fix path to compiled styles

### DIFF
--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -6,7 +6,7 @@ const { title } = Astro.props;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
-    <link href="/style.css" rel="stylesheet" />
+    <link href="/output.css" rel="stylesheet" />
   </head>
   <body class="font-sans bg-white text-gray-900">
     <header class="bg-white shadow p-4">


### PR DESCRIPTION
## Summary
- link correct Tailwind output in layout

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653c0249f08333b51f4aab3a21064f